### PR TITLE
Add 87 cycles to memory access

### DIFF
--- a/dfs.py
+++ b/dfs.py
@@ -8,7 +8,7 @@ from collections import deque
 CACHE_LINE_DIFF = 4
 COST_MEM_L1_HIT = 0
 COST_MEM_L2_HIT = 12
-COST_MEM_MISS = 87
+COST_MEM_MISS = 87 + 87
 CACHE_TTL_N = 8  # Set to 8/16 for test
 
 


### PR DESCRIPTION
* Increase `COST_MEM_MISS` to 174 cycles to reflect 87 (open row) + 87 (read).
* Since helper functions with imm=1,2,3 are also treated as memory access, their costs are also 174 cycles now.
* Please let me know if this looks good, and I'll rerun the tests immediately.